### PR TITLE
Update changelog with v1.1.2 and v1.1.3 product updates

### DIFF
--- a/changelog/overview.mdx
+++ b/changelog/overview.mdx
@@ -46,21 +46,7 @@ mode: "wide"
 - **File / Image Uploads on Agent UI:** Agent UI now supports file and image uploads with prompts.
     - Supported file formats: `.pdf` `.csv` `.txt` `.docx` `.json`
     - Supported image formats: `.png` `.jpeg` `.jpg` `.webp`
-- **Firecrawl Custom API URL**: Allowed users to set a custom API URL for Firecrawl.
-- **Gemini embedder update:** Updated the `GeminiEmbedder` to use the new [Google’s genai SDK](https://github.com/googleapis/python-genai). This update introduces a slight change in the interface:
-    
-    ```python
-    # Before
-    embeddings = GeminiEmbedder("models/text-embedding-004").get_embedding(
-        "The quick brown fox jumps over the lazy dog."
-    )
-    
-    # After
-    embeddings = GeminiEmbedder("text-embedding-004").get_embedding(
-        "The quick brown fox jumps over the lazy dog."
-    )
-    ```
-    
+- **Firecrawl Custom API URL**: Allowed users to set a custom API URL for Firecrawl.   
 - **Updated `ModelsLabTools` Toolkit Constructor**: The constructor in `/libs/agno/tools/models_labs.py` has been updated to accommodate audio generation API calls. This is a breaking change, as the parameters for the `ModelsLabTools` class have changed. The `url` and `fetch_url` parameters have been removed, and API URLs are now decided based on the `file_type` provided by the user.
     
     ```python

--- a/changelog/overview.mdx
+++ b/changelog/overview.mdx
@@ -2,6 +2,42 @@
 title: "Product updates"
 mode: "wide"
 ---
+<Update label="2025-02-16" description="v1.1.3">
+## 1.1.3
+
+## Bug Fixes:
+
+- **Gemini Tool-Call History**: Fixed an issue where Gemini rejected tool-calls from historic messages.
+</Update>
+
+<Update label="2025-02-15" description="v1.1.2">
+## 1.1.2
+
+## Improvements:
+
+- **Reasoning with o3 Models**: Reasoning support added for OpenAI’s o3 models.
+- **Gemini embedder update:** Updated the `GeminiEmbedder` to use the new [Google’s genai SDK](https://github.com/googleapis/python-genai). This update introduces a slight change in the interface:
+    
+    ```python
+    # Before
+    embeddings = GeminiEmbedder("models/text-embedding-004").get_embedding(
+        "The quick brown fox jumps over the lazy dog."
+    )
+    
+    # After
+    embeddings = GeminiEmbedder("text-embedding-004").get_embedding(
+        "The quick brown fox jumps over the lazy dog."
+    )
+    ```
+    
+
+## Bug Fixes:
+
+- **Singlestore Fix:** Fixed issue where when querying singlestore the embeddings column was returning in binary format.
+- **MongoDB Vectorstore Fix:** MongoDB had multiple issues like creating and dropping the collections twice while initialising. All known issues were fixed.
+- **LanceDB Fix:** Fixed various errors on LanceDB and added `on_bad_vectors` as parameters.
+</Update>
+
 <Update label="2025-02-14" description="v1.1.1">
 ## 1.1.1 
 


### PR DESCRIPTION
- Add changelog entry for version 1.1.2 and 1.1.3
- Include improvements for o3 models and Gemini embedder
- Document bug fixes for Singlestore, MongoDB Vectorstore, and LanceDB
- Update code example for Gemini embedder initialization