### PR TITLE
fix: Groq:docs

### DIFF
--- a/models/groq.mdx
+++ b/models/groq.mdx
@@ -8,7 +8,7 @@ See all the Groq supported models [here](https://console.groq.com/docs/models).
 
 - We recommend using `llama-3.3-70b-versatile` for general use
 - We recommend `llama-3.1-8b-instant` for a faster result.
-- We recommend using `llama-3.2-90b-vision-preview` for image understanding.
+- We recommend using `meta-llama/llama-4-scout-17b-16e-instruct` for image understanding.
 
 #### Multimodal Support
 


### PR DESCRIPTION
The model `llama-3.2-90b-vision-preview`, has been decommissioned and is no longer supported as per [Groq](https://console.groq.com/docs/deprecations#april-14-2025-multiple-model-deprecations) official April 2025 deprecations. Groq recommends `meta-llama/llama-4-scout-17b-16e-instruct`.