### PR TITLE
[FIX] SERP_API_KEY naming

### DIFF
--- a/tools/toolkits/search/serpapi.mdx
+++ b/tools/toolkits/search/serpapi.mdx
@@ -13,7 +13,7 @@ pip install -U google-search-results
 ```
 
 ```shell
-export SERPAPI_API_KEY=***
+export SERP_API_KEY=***
 ```
 
 ## Example


### PR DESCRIPTION
SERP_API_KEY to be used instead of SERPAPI_API_KEY