### PR TITLE
Update structured-output.mdx

### DIFF
--- a/agents/structured-output.mdx
+++ b/agents/structured-output.mdx
@@ -78,7 +78,7 @@ MovieScript(
 
 ## Using a Parser Model
 
-You can use an additional model to parse and structure the output from your primary model. This approach is particularly effective when the primary model is optimized for reasoning tasks, as such models may not consistently produce detailed structured responses.
+You can use an additional model to parse and structure the output from your primary model. A `parser_model` can be employed to transform the raw response into structured output, replacing the default model for this specific task. This approach is particularly effective when the primary model is optimized for reasoning tasks, as such models may not consistently produce detailed structured responses. 
 
 ```python
 agent = Agent(


### PR DESCRIPTION
Modify structured-output.mdx to clarify use of parser_model as replacement for default model.

Reference:
* If specified `parser_model`, agno will use it to structure the response separately
  * https://github.com/agno-agi/agno/blob/e9d640f53cf3d31e832d06e920c937bf2a365193/libs/agno/agno/agent/agent.py#L6125C9-L6125C49
* Otherwise, the provided `model` will be used both for generate response and specify for the response format
  * for ChatGPT like: https://github.com/agno-agi/agno/blob/e9d640f53cf3d31e832d06e920c937bf2a365193/libs/agno/agno/models/openai/chat.py#L433
  * for Google Gemini: https://github.com/agno-agi/agno/blob/e9d640f53cf3d31e832d06e920c937bf2a365193/libs/agno/agno/models/google/gemini.py#L269