### PR TITLE
fix: replace undefined variable 'fc' in HITL confirmation_hook

### DIFF
--- a/tools/hitl.mdx
+++ b/tools/hitl.mdx
@@ -58,7 +58,7 @@ def confirmation_hook(
     live.stop()  # type: ignore
 
     # Ask for confirmation
-    console.print(f"\nAbout to run [bold blue]{fc.function.name}[/]")
+    console.print(f"\nAbout to run [bold blue]{function_name}[/]")
     message = (
         Prompt.ask("Do you want to continue?", choices=["y", "n"], default="y")
         .strip()


### PR DESCRIPTION
Fixed a NameError in the Human-in-the-Loop (HITL) example where the confirmation_hook function incorrectly references an undefined variable fc, causing the example to fail when run. The fix replaces fc.function.name with the correct function_name parameter passed into the hook, ensuring the example runs correctly.