### PR TITLE
docs: fix broken link for contribution guidelines page

### DIFF
--- a/how-to/contribute.mdx
+++ b/how-to/contribute.mdx
@@ -39,6 +39,6 @@ Ensure your code meets our quality standards by running the appropriate formatti
 
 These scripts will perform code formatting with `ruff` and static type checks with `mypy`.
 
-Read more about the guidelines [here](https://github.com/agno-agi/agno/tree/main/cookbook/CONTRIBUTING.md)
+Read more about the guidelines [here](https://github.com/agno-agi/agno/blob/main/CONTRIBUTING.md)
 
 Message us on [Discord](https://discord.gg/4MtYHHrgA8) or post on [Discourse](https://community.agno.com/) if you have any questions or need help with credits.


### PR DESCRIPTION
The original [Contributing to Agno](https://docs.agno.com/how-to/contribute) page contained a broken URL pointing to the `CONTRIBUTING.md` file.

This PR corrects the link to ensure it properly references the intended file.

- Broken link: https://github.com/agno-agi/agno/tree/main/cookbook/CONTRIBUTING.md
- Fixed link: https://github.com/agno-agi/agno/blob/main/CONTRIBUTING.md