### PR TITLE
docs: fix typos and duplication in supported vectordb list

### DIFF
--- a/vectordb/introduction.mdx
+++ b/vectordb/introduction.mdx
@@ -47,8 +47,6 @@ This capability allows for more flexible and powerful querying, often yielding b
 
 The following VectorDb are currently supported:
 
-- [PgVector](/vectordb/pgvector)\*
-- [Azure Cosmos MongoDB](/vectordb/azure-cosmos-mongodb)
 - [Cassandra](/vectordb/cassandra)
 - [ChromaDb](/vectordb/chroma)
 - [Clickhouse](/vectordb/clickhouse)
@@ -56,6 +54,7 @@ The following VectorDb are currently supported:
 - [LanceDb](/vectordb/lancedb)\*
 - [Milvus](/vectordb/milvus)
 - [MongoDb](/vectordb/mongodb)
+- [Azure Cosmos MongoDB](/vectordb/azure_cosmos_mongodb)
 - [PgVector](/vectordb/pgvector)\*
 - [Pinecone](/vectordb/pinecone)\*
 - [Qdrant](/vectordb/qdrant)


### PR DESCRIPTION
Fix issues in the Supported Vector Databases list:
- Removed duplicate PgVector entry
- Corrected Azure Cosmos MongoDB link
