### PR TITLE
docs: fix virtual env activation command for windows

### DIFF
--- a/agent-ui/introduction.mdx
+++ b/agent-ui/introduction.mdx
@@ -127,7 +127,7 @@ In another terminal, run the playground server:
 
     ```bash Windows
     python3 -m venv aienv
-    aienv/scripts/activate
+    aienv\Scripts\activate
     ```
     </CodeGroup>
 

--- a/how-to/install.mdx
+++ b/how-to/install.mdx
@@ -19,7 +19,7 @@ We highly recommend:
 
     ```bash Windows
     python3 -m venv agnoenv
-    agnoenv/scripts/activate
+    agnoenv\Scripts\activate
     ```
 
     </CodeGroup>


### PR DESCRIPTION
This PR corrects the virtual environment activation commands for Windows setup, which were previously inaccurate in the documentation.

- https://docs.agno.com/how-to/install#install-agno
- https://docs.agno.com/agent-ui/introduction#connect-to-local-agents