### PR TITLE
fix: update broken links to Docker and AWS templates

### DIFF
--- a/deploy/introduction.mdx
+++ b/deploy/introduction.mdx
@@ -10,8 +10,8 @@ You can build, test, and improve your AgentOS locally, but to run it in producti
 
 Currently supported templates:
 
-Docker Template: [agent-infra-docker](https://github.com/agentos-ai/agent-infra-docker)
-AWS Template: [agent-infra-aws](https://github.com/agentos-ai/agent-infra-aws)
+Docker Template: [agent-infra-docker](https://github.com/agno-agi/agno/tree/main/libs/agno_infra/agno/docker)
+AWS Template: [agent-infra-aws](https://github.com/agno-agi/agno/tree/main/libs/agno_infra/agno/aws)
 
 Coming soon:
 

--- a/deploy/introduction.mdx
+++ b/deploy/introduction.mdx
@@ -10,8 +10,8 @@ You can build, test, and improve your AgentOS locally, but to run it in producti
 
 Currently supported templates:
 
-Docker Template: [agent-infra-docker](https://github.com/agno-agi/agno/tree/main/libs/agno_infra/agno/docker)
-AWS Template: [agent-infra-aws](https://github.com/agno-agi/agno/tree/main/libs/agno_infra/agno/aws)
+Docker Template: [agent-infra-docker](https://github.com/agno-agi/agent-infra-docker)
+AWS Template: [agent-infra-aws](https://github.com/agno-agi/agent-infra-aws)
 
 Coming soon:
 


### PR DESCRIPTION
fix: update broken links to Docker and AWS templates

Updated old GitHub URLs to point to the new repository structure
with correct tree/main paths for the Docker and AWS folders.